### PR TITLE
Add doc to provision postgres before migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ After `post_compile` is successful, uncomment the line with the variable `STATIC
 
     git commit -am "Enabled django-pipeline"
     git push heroku master
+    heroku addons:create heroku-postgresql
     heroku run django-admin.py migrate
     heroku open
 


### PR DESCRIPTION
Need to provision PostgreSQL on Heroku before running migrate or it will fail.

Closes https://github.com/imkevinxu/django-kevin/issues/6.
